### PR TITLE
Add support for if expressions (ternary operator)

### DIFF
--- a/src/shady.nim
+++ b/src/shady.nim
@@ -540,6 +540,33 @@ proc toCode(n: NimNode, res: var string, level = 0) =
       echo n.treeRepr
       err "Some sort of object constructor", n
 
+  of nnkIfExpr:
+    var gotElse = false
+    res.add "("
+    for subn in n:
+      case subn.kind
+      of nnkElifExpr:
+        if gotElse:
+          echo n.treeRepr
+          err "Cannot have elif after else", n
+        res.add "("
+        subn[0].toCode(res)
+        res.add ") ? ("
+        subn[1].toCode(res)
+        res.add ") : "
+      of nnkElseExpr:
+        gotElse = true
+        res.add "("
+        subn[0].toCode(res)
+        res.add ")"
+      else:
+        echo n.treeRepr
+        err "Invalid child of nnkIfExpr: " & subn.kind.repr, n
+    res.add ")"
+    if not gotElse:
+      echo n.treeRepr
+      err "nnkIfExpr is missing an else clause", n
+
   else:
     echo n.treeRepr
     err "Can't compile", n

--- a/tests/test_shady.nim
+++ b/tests/test_shady.nim
@@ -112,3 +112,27 @@ block:
       color = in_color
       gl_Position = position
   echo toGLSL(vertexShade, "300 es")
+
+block:
+  echo "--------------------------------------------------"
+  echo "Ternary operator."
+
+  proc ternaryOperator(fragColor: var Vec4, normal: Vec3) =
+    fragColor = vec4(
+      if normal.x <= 0: 0 else: 1,
+      if normal.y <= 0:
+        0
+      else:
+        1,
+      if normal.z < -0.5:
+        -0.5
+      elif normal.z < 0:
+        0
+      else:
+        1,
+      1)
+
+  echo toGLSL(ternaryOperator)
+  var c: Vec4
+  ternaryOperator(c, vec3(-1.0, 1.0, -0.6))
+  assert c == vec4(0.0, 1.0, -0.5, 1.0)


### PR DESCRIPTION
This pull request adds support for `if` expressions in Nim shaders, that get translated to ternary operators in GLSL.

The idea here is that `elif` statements will result in chained ternary operators, finished by an `else`.

For example, the following expression:
```nim
let a: float = if normal.z < -0.5:
        -0.5
      elif normal.z < 0:
        0
      else:
        1
```
would be translated to:
```glsl
float a = ((float(normal.z) < -0.5) ? (-0.5) : (normal.z < 0.0) ? (0.0) : (1.0));
```
It seems to me that the Nim compiler won't have `if` expressions that don't finish with an `else`, or `else` nodes before an `elif` node, but checking doesn't hurt, does it?