### PR TITLE
compute.nim windy newWindow API fix

### DIFF
--- a/src/shady/compute.nim
+++ b/src/shady/compute.nim
@@ -29,8 +29,7 @@ proc initOffscreenWindow*(size = ivec2(100, 100)) =
       size = size,
       # style = Undecorated,
       visible = false,
-      openglMajorVersion = 4,
-      openglMinorVersion = 5,
+      openglVersion = OpenGL4Dot5,
     )
     window.makeContextCurrent()
     loadExtensions()


### PR DESCRIPTION
`compute.nim` calls `newWindow` from `windy` and API seems to have changed. Shouldn't `windy` also be included in `requires` so the API is fixed to a version? You also get an error when trying to use compute shaders for a first time since `windy` is not automatically installed.