### PR TITLE
Release 0.1.5

### DIFF
--- a/shady.nimble
+++ b/shady.nimble
@@ -1,4 +1,4 @@
-version     = "0.1.4"
+version     = "0.1.5"
 author      = "Andre von Houck"
 description = "Nim to GPU shader language compiler and supporting utilities."
 license     = "MIT"


### PR DESCRIPTION

- Bump the Shady package version from 0.1.4 to 0.1.5.
- Publish the latest master fixes behind a new release version for downstream packages.
