### PR TITLE
Update Shady README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ Shady has two main goals:
 * Write vertex and fragment/pixel shaders for games and 3d applications.
 * Write compute shaders for offline processing and number crunching.
 
+Currently supported shader types:
+
+* Fragment/pixel shaders, including shader-toy style fullscreen examples.
+* Vertex shaders paired with fragment shaders for the traditional graphics pipeline.
+* Compute shaders for GPU data processing.
+
+Current GLSL targets:
+
+* Desktop GLSL via `glslDesktop` for OpenGL 4.1+.
+* GLSL ES 3.0 via `glslES3` for OpenGL ES 3.0 / WebGL 2.0.
+
 Shady uses:
 * `pixie` library for image operations.
 * `vmath` library for vector and matrix operations.
@@ -24,29 +35,35 @@ Shady uses:
 ![circle example](docs/circle.png)
 
 ```nim
+import shady, vmath, shady/demo
+
 # both CPU and GPU code:
-proc circleSmooth(gl_FragColor: var Color, uv: Vec2) =
+proc circleSmooth(fragColor: var Vec4, uv: Vec2, time: Uniform[float32]) =
   var a = 0.0
+  var radius = 300.0 + 100 * sin(time)
   for x in 0 ..< 8:
     for y in 0 ..< 8:
-      if (uv + vec2(x.float32 - 4.0, y.float32 - 4.0) / 8.0).length < 400.0:
+      if (uv + vec2(x.float32 - 4.0, y.float32 - 4.0) / 8.0).length < radius:
         a += 1
   a = a / (8 * 8)
-  gl_FragColor = color(a, a, a, 1)
+  fragColor = vec4(a, a, a, 1)
 
 # test on the CPU:
-var testColor: Color
-circleSmooth(testColor, vec2(100, 100))
+var testColor: Vec4
+circleSmooth(testColor, vec2(100, 100), 0.0)
 echo testColor
 
 # compile to a GPU shader:
 var shader = toGLSL(circleSmooth)
 echo shader
+
+# run the GPU shader and display it in a window:
+run("Circle", shader)
 ```
 
 [See the source](examples/circle.nim)
 
-![mandlebrot example](docs/mandelbrot.png)
+![mandelbrot example](docs/mandelbrot.png)
 
 [See the source](examples/mandelbrot.nim)
 
@@ -70,12 +87,12 @@ Nim vertex shader:
 proc basicVert(
   gl_Position: var Vec4,
   MVP: Uniform[Mat4],
-  vCol: Attribute[Vec3],
-  vPos: Attribute[Vec3],
-  fragColor: var Vec3
+  vCol: Vec3,
+  vPos: Vec3,
+  vertColor: var Vec3
 ) =
   gl_Position = MVP * vec4(vPos.x, vPos.y, 0.0, 1.0)
-  fragColor = vCol
+  vertColor = vCol
 ```
 
 GLSL output:
@@ -86,18 +103,18 @@ precision highp float;
 uniform mat4 MVP;
 attribute vec3 vCol;
 attribute vec3 vPos;
-out vec3 fragColor;
+out vec3 vertColor;
 
 void main() {
   gl_Position = MVP * vec4(vPos.x, vPos.y, 0.0, 1.0);
-  fragColor = vCol;
+  vertColor = vCol;
 }
 ```
 
 Nim fragment shader:
 ```nim
-proc basicFrag(gl_FragColor: var Color, fragColor: Vec3) =
-  gl_FragColor = color(fragColor.x, fragColor.y, fragColor.z, 1.0)
+proc basicFrag(fragColor: var Vec4, vertColor: Vec3) =
+  fragColor = vec4(vertColor.x, vertColor.y, vertColor.z, 1.0)
 ```
 
 GLSL output:
@@ -105,16 +122,16 @@ GLSL output:
 #version 410
 precision highp float;
 
-in vec3 fragColor;
+in vec3 vertColor;
 
 void main() {
-  gl_FragColor = vec4(fragColor.x, fragColor.y, fragColor.z, 1.0);
+  gl_FragColor = vec4(vertColor.x, vertColor.y, vertColor.z, 1.0);
 }
 ```
 
 # Using Shady to write compute shaders:
 
-Shady can be used to write compute shaders. Compute shaders allow more general purpose code execution work in parallel and hence faster then the CPU.
+Shady can be used to write compute shaders. Compute shaders allow more general purpose code execution work in parallel and are often faster than the CPU for this kind of workload.
 
 ```nim
 # Setup the uniforms.


### PR DESCRIPTION
## Summary
- refresh the README examples so the circle and triangle snippets match the current Shady API and examples in `master`
- document the shader types currently supported and note the available GLSL targets
- fix a small README typo while updating the docs

## Test plan
- [x] Compared README snippets against `examples/circle.nim`, `examples/triangle.nim`, and `src/shady.nim`
- [ ] Build and run examples locally