### PR TITLE
CI: move to setup-nim-action@v6 (Nimby 0.2.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,22 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: treeform/setup-nim-action@v5
-    - run: nimby install -g shady.nimble
+    - uses: actions/checkout@v5
+    - uses: treeform/setup-nim-action@v6
+
+    # Nimby installs packages as siblings of the workspace root, so the
+    # workspace has to be the parent of this checkout: shady then sits inside
+    # it next to its dependencies and nim finds nim.cfg by walking up.
+    - name: Create a Nimby workspace
+      shell: bash
+      run: |
+        cd ..
+        nimby create
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        cd ..
+        nimby install shady/shady.nimble
+
     - run: nim r tests/test_shady.nim

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,21 +4,36 @@ on:
     branches:
       - master
 env:
-  nim-version: 'stable'
   nim-src: src/${{ github.event.repository.name }}.nim
   deploy-dir: .gh-pages
 jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: jiro4989/setup-nim-action@v1
-        with:
-          nim-version: ${{ env.nim-version }}
-      - run: nimble install -Y
-      - run: nimble doc --index:on --project --git.url:https://github.com/${{ github.repository }} --git.commit:master  --out:${{ env.deploy-dir }} ${{ env.nim-src }}
+      - uses: actions/checkout@v5
+      - uses: treeform/setup-nim-action@v6
+
+      # Nimby installs packages as siblings of the workspace root, so the
+      # workspace has to be the parent of this checkout: shady then sits inside
+      # it next to its dependencies and nim finds nim.cfg by walking up.
+      - name: Create a Nimby workspace
+        shell: bash
+        run: |
+          cd ..
+          nimby create
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          cd ..
+          nimby install shady/shady.nimble
+
+      - name: Generate documentation
+        run: nim doc --index:on --project --git.url:https://github.com/${{ github.repository }} --git.commit:master  --out:${{ env.deploy-dir }} ${{ env.nim-src }}
+
       - name: "Copy to index.html"
         run: cp ${{ env.deploy-dir }}/${{ github.event.repository.name }}.html ${{ env.deploy-dir }}/index.html
+
       - name: Deploy documents
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
Moves CI to `treeform/setup-nim-action@v6`, which ships Nim 2.2.10 with **Nimby 0.2.0** bundled.

Not just a tag bump — Nimby 0.2.0 made workspaces explicit, which breaks the old command.

### What was breaking

`nimby install -g shady.nimble` in the checkout root now fails outright under 0.2.0:

```
Can't add package 'shady' to config.
Nimble file not found for package 'shady'
```

and the build then fails with `Error: cannot open file: pixie`. Verified against the real v6 toolchain.

The workspace is now created in the checkout's **parent**, so shady sits inside it next to its dependencies and nim finds `nim.cfg` by walking up. That placement is load-bearing: a workspace under `RUNNER_TEMP` installs the packages but the build won't see them.

### docs.yml

Migrated off `jiro4989/setup-nim-action@v1` + `nimble` onto the same Nimby workspace and `nim doc`, so both workflows use one toolchain. Dropped the unused `nim-version: 'stable'` env (v6 requires an exact version and this was never passed to the action).

### Verification

Every `run:` step was parsed from these YAML files and executed against the bit-identical v6 artifact (SHA-256 matched the release asset), in a sandbox with `USERPROFILE` redirected:

- `build.yml` — workspace + install + `nim r tests/test_shady.nim` actually runs and passes
- `docs.yml` — full run, produces the expected `.gh-pages` tree with `index.html`

Note this only changes shady's own CI. Downstream repos consume shady as a git clone at HEAD, so they are unaffected.

Local runs were Windows-only; this PR's CI covers the ubuntu matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)