### PR TITLE
Fix Uniform[Mat4] and other Uniform[T] params on shader entry points

### DIFF
--- a/src/shady/backends/shared.nim
+++ b/src/shady/backends/shared.nim
@@ -115,9 +115,11 @@ proc typeString(n: NimNode): string =
     of "GVec2[int32]": typeRename("IVec2")
     of "GVec3[int32]": typeRename("IVec3")
     of "GVec4[int32]": typeRename("IVec4")
-    of "Uniform[float32]": typeRename("float32")
-    of "Uniform[int]": typeRename("int")
     else:
+      if n[0].repr in ["Uniform", "UniformWriteOnly", "Attribute"]:
+        # Uniform[T], UniformWriteOnly[T] and Attribute[T] are just T
+        # in the shader, so use the inner type.
+        return typeString(n[1])
       if n[0].repr == "array":
         var length = 0
         if n[1].kind == nnkIntLit:
@@ -983,7 +985,22 @@ proc toCodeTopLevel(
               res.add "out "
               res.add typeRename(typeNode[0].strVal)
             else:
-              if typeNode.kind == nnkBracketExpr:
+              if typeNode.kind == nnkBracketExpr and
+                  typeNode[0].repr in ["Uniform", "UniformWriteOnly", "Attribute"]:
+                # Uniform[T] params become uniform globals, not "in" params.
+                res.add typeRename(typeNode[0].repr)
+                res.add " "
+                let (innerType, arraySuffix) = splitArrayType(typeNode[1])
+                if shaderTarget == glslES3 and glsl3NeedsHighp(innerType):
+                  res.add "highp "
+                res.add innerType
+                res.add " "
+                res.add param.strVal
+                res.add arraySuffix
+                res.addSmart ';'
+                res.add "\n"
+                continue
+              elif typeNode.kind == nnkBracketExpr:
                 if isVulkan():
                   res.add "layout(location = "
                   res.add $inLocation

--- a/tests/test_shady.nim
+++ b/tests/test_shady.nim
@@ -384,6 +384,31 @@ block:
     fragColor = vec4(float(tile.x), 0.0, 0.0, 1.0)
   log toGLSL(desktopSamplerFrag, glslDesktop)
 
+block:
+  log "--------------------------------------------------"
+  log "Uniform params on the entry point (issue #32):"
+  proc uniformParamVert(
+    gl_Position: var Vec4,
+    MVP: Uniform[Mat4],
+    vCol: Vec3,
+    vPos: Vec3,
+    vertColor: var Vec3
+  ) =
+    gl_Position = MVP * vec4(vPos.x, vPos.y, 0.0, 1.0)
+    vertColor = vCol
+  log toGLSL(uniformParamVert)
+
+block:
+  log "--------------------------------------------------"
+  log "Uniform float param on the entry point:"
+  proc uniformParamFrag(
+    fragColor: var Vec4,
+    uv: Vec2,
+    time: Uniform[float32]
+  ) =
+    fragColor = vec4(uv.x, uv.y, sin(time), 1.0)
+  log toGLSL(uniformParamFrag)
+
 when defined(gen_master):
   writeFile(goldMasterPath, masterOutput)
 else:

--- a/tests/test_shady.txt
+++ b/tests/test_shady.txt
@@ -507,3 +507,33 @@ void main() {
   fragColor = vec4(float(float(tile.x)), 0.0, 0.0, 1.0);
 }
 
+--------------------------------------------------
+Uniform params on the entry point (issue #32):
+#version 410
+precision highp float;
+// from uniformParamVert
+
+uniform mat4 MVP;
+in vec3 vCol;
+in vec3 vPos;
+out vec3 vertColor;
+
+void main() {
+  gl_Position = MVP * vec4(vPos.x, vPos.y, 0.0, 1.0);
+  vertColor = vCol;
+}
+
+--------------------------------------------------
+Uniform float param on the entry point:
+#version 410
+precision highp float;
+// from uniformParamFrag
+
+out vec4 fragColor;
+in vec2 uv;
+uniform float time;
+
+void main() {
+  fragColor = vec4(uv.x, uv.y, sin(time), 1.0);
+}
+


### PR DESCRIPTION
Fixes #32.

`toGLSL` failed with `[Shady] can't figure out type: Uniform[Mat4]` on the README/triangle-example vertex shader. Two fixes in `shared.nim`:

1. **Type resolution**: `typeString` only recognized `Uniform[float32]` and `Uniform[int]` as hardcoded string cases, so any other wrapped type (`Uniform[Mat4]`, `Uniform[Vec2]`, …) fell through to the error. Now it recurses into the inner type for `Uniform`, `UniformWriteOnly`, and `Attribute` wrappers.

2. **Emission**: entry-point params wrapped in `Uniform` were emitted as plain `in` params (`in mat4 MVP;`). The examples bind these via `glGetUniformLocation`, so they are now emitted as uniform globals (`uniform mat4 MVP;`), reusing the ES3 `highp` sampler handling and array suffix logic from the global-var path.

The issue's shader now produces:

```glsl
#version 410
precision highp float;

uniform mat4 MVP;
in vec3 vCol;
in vec3 vPos;
out vec3 vertColor;

void main() {
  gl_Position = MVP * vec4(vPos.x, vPos.y, 0.0, 1.0);
  vertColor = vCol;
}
```

Added two gold-master regression tests (the issue's vertex shader and a `Uniform[float32]` fragment param); the gold-master diff is purely additive. `nimble test` passes, and `examples/triangle.nim` (which uses this exact pattern and previously failed to compile) now builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)